### PR TITLE
Update to official IoT Toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ For example, create and manage connection profiles and most recently used connec
 
 ## Internet of Things
 
-The [Azure IoT Toolkit](https://marketplace.visualstudio.com/items?itemName=formulahendry.azure-iot-toolkit) for VS Code makes it easy to develop and connect your [IoT applications to Azure](https://docs.microsoft.com/en-us/azure/index#pivot=services&panel=iot). With this extension, you can send messages to the Azure IoT Hub (device-to-cloud message), monitor device-to-cloud messages, manage devices, and discove devices connected via Ethernet, USB serial, and over WiFi.
+The [Azure IoT Toolkit](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-toolkit) for VS Code makes it easy to develop and connect your [IoT applications to Azure](https://docs.microsoft.com/en-us/azure/index#pivot=services&panel=iot). With this extension, you can send messages to the Azure IoT Hub (device-to-cloud message), monitor device-to-cloud messages, manage devices, and discover devices connected via Ethernet, USB serial, and over WiFi.
 
 ## Functions
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-azureextensionpack",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "publisher": "ms-vscode",
     "displayName": "Azure Extension Pack",
     "description": "A collection of extensions for working with Azure resources in VS Code",
@@ -30,7 +30,7 @@
     "extensionDependencies": [
         "PeterJausovec.vscode-docker",
         "bradygaster.azuretoolsforvscode",
-        "formulahendry.azure-iot-toolkit",
+        "vsciot-vscode.azure-iot-toolkit",
         "ms-mssql.mssql",
         "msazurermtools.azurerm-vscode-tools",
         "usqlextpublisher.usql-vscode-ext",


### PR DESCRIPTION
[formulahendry.azure-iot-toolkit](https://marketplace.visualstudio.com/items?itemName=formulahendry.azure-iot-toolkit) is now deprecated in favor of the [Microsoft version](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.azure-iot-toolkit)